### PR TITLE
Cleanup: Add unused pragmas where needed

### DIFF
--- a/MusicKit/MKMIDIProc.m
+++ b/MusicKit/MKMIDIProc.m
@@ -10,6 +10,7 @@ static MKMIDINotifyCallback _notifyCallback = nil;
  http://www.gweep.net/~prefect/eng/reference/protocol/midispec.html
  */
 static void readProc(const MIDIPacketList *packetList, void *procRef, void *srcRef) {
+#pragma unused(procRef, srcRef)
     if (!_readCallback) {
         return;
     }
@@ -62,6 +63,7 @@ static void readProc(const MIDIPacketList *packetList, void *procRef, void *srcR
 }
 
 static void notifyProc(const MIDINotification *notification, void *refCon) {
+#pragma unused(refCon)
     if (!_notifyCallback) {
         return;
     }


### PR DESCRIPTION
ping @benzguo 

This doesnt build with Warnings as Errors and a higher than default setting of warnings
due to unused variables. Thus we need to insert pragmas where needed.